### PR TITLE
Fix reading font from configuration file

### DIFF
--- a/wf-metacity-decorator/main.cpp
+++ b/wf-metacity-decorator/main.cpp
@@ -180,7 +180,7 @@ static void load_config ()
 static void send_borders (const char *font)
 {
     int text_height;
-    PangoFontDescription *font_desc = pango_font_description_from_string(font);
+    font_desc = pango_font_description_from_string(font);
     GtkWidget *window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     GtkStyleContext *style_gtk = gtk_widget_get_style_context (window);
     
@@ -243,6 +243,7 @@ static void activate (GtkApplication* app, gpointer)
     meta_theme_set_current(val.c_str(), TRUE);
     metatheme = meta_theme_get_current();
     
+    /*FIXME: string handling*/
     val = config["button-layout"];
     meta_update_button_layout (val.c_str(), &button_layout);
     val = config["dialog-button-layout"];


### PR DESCRIPTION
*cppcheck found this, and it fixes a failure to apply the font asked for in the configuration json file
*In at least some build environments, shadowing the outer variable declaration causes the new value to be discarded it seems. In this case, it causes the font selected by the user to be ignored.